### PR TITLE
delete 乐人.png from res.qrc

### DIFF
--- a/res.qrc
+++ b/res.qrc
@@ -30,7 +30,6 @@
         <file>icon/euro.svg</file>
         <file>icon/SouthKorea.svg</file>
         <file>icon/华.svg</file>
-        <file>icon/乐人.png</file>
         <file>icon/hand.png</file>
         <file>icon/5sing.png</file>
         <file>icon/fanxing.png</file>


### PR DESCRIPTION
在win下编译代码出现 “no rule to make target ??.png”错误，从res.qrc文件中删除 "乐人.png"即可。